### PR TITLE
Cleanup after complete

### DIFF
--- a/roundabout/__init__.py
+++ b/roundabout/__init__.py
@@ -61,3 +61,5 @@ class Roundabout(object):
                         pull_request.close("Build successful!")
                     else:
                         pull_request.close("Build failed, rejecting.")
+
+                    git.cleanup()

--- a/roundabout/git_client.py
+++ b/roundabout/git_client.py
@@ -2,6 +2,7 @@
 
 import git
 import os
+import shutil
 
 from git import Repo, GitCommandError #pylint: disable=E1101
 from random import choice
@@ -56,6 +57,16 @@ class Git(object):
         """ Return the head object referenced by the branch name """
         return [b for b in self.repo.branches if branch == b.name][0]
 
+    def cleanup(self):
+        if self.local_branch_name == 'master':
+            raise GitException("Attempted to delete your remote master!")
+        
+        self.push(":%s" % self.local_branch_name)
+        try:
+            shutil.rmtree(self.clonepath)
+        except OSError, e:
+            raise GitException(e)
+
     def merge(self, branch):
         """ Merge the passed in branch with HEAD """
 
@@ -69,5 +80,3 @@ class Git(object):
         """ Push the branch up to the remote """
         log.info("pushing %s to %s" % (branch, remote))
         return self.repo.remote(remote).push(branch)
-
-

--- a/roundabout/github/client.py
+++ b/roundabout/github/client.py
@@ -110,7 +110,6 @@ class PullRequest(object):
                LGTM_RE.match(comment.get('body', "")):
                 return True
 
-
     def __get_full_request(self):
         """
         Return a dict of the complete pull_request data from the github api

--- a/tests/git_unittest.py
+++ b/tests/git_unittest.py
@@ -88,6 +88,39 @@ class GitTestCase(unittest.TestCase):
 
         self.assertTrue(repo.push('master'))
 
+    def test_cleanup_master_raises(self):
+        config = Config(config_files=[utils.testdata('good_git.cfg')])
+        remote_name = config.git_test_remote_name
+        remote_url = config.git_test_remote_url
+        remote_branch = config.git_test_remote_branch
+
+        repo = Git(remote_name=remote_name,
+                   remote_url=remote_url,
+                   remote_branch=remote_branch)
+        repo.local_branch_name = 'master'
+
+        self.assertRaises(GitException, repo.cleanup)
+
+    def test_cleanup_with_good_config_doesnt_raise(self):
+        config = Config(config_files=[utils.testdata('good_git.cfg')])
+        remote_name = config.git_test_remote_name
+        remote_url = config.git_test_remote_url
+        remote_branch = config.git_test_remote_branch
+
+        repo = Git(remote_name=remote_name,
+                   remote_url=remote_url,
+                   remote_branch=remote_branch)
+
+        try:
+            repo.cleanup()
+        except GitException, e:
+            result = False
+        else:
+            result = True
+
+        self.assertTrue(result)
+
+
     def test_clone_repo_with_bad_config(self):
         config = Config(config_files=[utils.testdata('bad_git.cfg')])
         remote_name = config.git_test_remote_name


### PR DESCRIPTION
This adds a cleanup method to the Git class that removes the merge_X branch and the cloned repo. The method is called after a job is completed and closed (whether that close was for a build success or build failure).
