### PR TITLE
Fatal exit error

### DIFF
--- a/roundabout/__init__.py
+++ b/roundabout/__init__.py
@@ -3,7 +3,7 @@
 import sys
 import time
 from roundabout import log
-from roundabout.git_client import Git, GitException
+from roundabout import git_client
 from roundabout.github.client import Client
 from roundabout.hudson import Job
 
@@ -30,9 +30,9 @@ class Roundabout(object):
             for url, pull_request in pull_requests:
                 log.info("processing %s" % url)
 
-                repo = Git(remote_name=pull_request.remote_name,
-                           remote_url=pull_request.remote_url,
-                           remote_branch=pull_request.remote_branch)
+                repo = git_client.Git(remote_name=pull_request.remote_name,
+                                      remote_url=pull_request.remote_url,
+                                      remote_branch=pull_request.remote_branch)
 
                 # Create a remote, fetch it, checkout the branch
 
@@ -40,8 +40,8 @@ class Roundabout(object):
                     log.info("Cloning to %s" % repo.clonepath)
                     try:
                         git.merge('master')
-                    except GitException, e:
-                        pull_request.close("Merge failed, rejecting.\n\n %s", e)
+                    except git_client.GitException, e:
+                        pull_request.close(git_client.MERGE_FAIL_MSG % e)
                         continue
 
                     git.push(git.local_branch_name)
@@ -58,8 +58,6 @@ class Roundabout(object):
                         # Successful build, good coverage, and clean pylint.
                         git.merge(git.local_branch_name)
                         git.push('master')
-                        pull_request.close("Build successful!")
+                        pull_request.close(git_client.BUILD_SUCCESS_MSG)
                     else:
-                        pull_request.close("Build failed, rejecting.")
-
-                repo.cleanup()
+                        pull_request.close(git_client.BUILD_FAIL_MSG)

--- a/roundabout/hudson.py
+++ b/roundabout/hudson.py
@@ -38,10 +38,7 @@ class Job(object):
                                   in job.builds 
                                   if build_id == build.number][0]
                 except IndexError:
-                    if opener:
-                        raise
-                    else:
-                        time.sleep(1)
+                    time.sleep(1)
 
     @property
     def properties(self):

--- a/tests/hudson_unittest.py
+++ b/tests/hudson_unittest.py
@@ -5,7 +5,7 @@ from roundabout.config import Config
 from roundabout.hudson import Job
 from tests import utils
 
-class HudsonTestCase(unittest.TestCase):
+class HudsonTestCase(utils.TestHelper):
     def setUp(self):
         self.t = time.time()
         self.config = Config()
@@ -35,7 +35,15 @@ class HudsonTestCase(unittest.TestCase):
             def read(self):
                 return json.JSONEncoder().encode(self.expected)
 
-        self.assertRaises(IndexError, Job.spawn_build, 'test_branch', opener=FakeHudson)
+        def fake_sleep(seconds):
+            """ stub out time.sleep so we can make sure it's called """
+            raise RuntimeError(seconds)
+
+        time.sleep = fake_sleep
+        try:
+            self.assertCalled(time.sleep, Job.spawn_build, 'test_branch', opener=FakeHudson)
+        except RuntimeError:
+            pass
 
     def test_get_job_data(self):
         job = Job()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,7 @@
 import json
 import os
+import unittest
+
 from roundabout.config import Config
 
 def testdata(filename):
@@ -12,3 +14,23 @@ def load(filename):
 def reset_config():
     # Reset config
     Config.__shared_state__.clear()
+
+class was_called(object):
+    def __init__(self, method):
+        self.was_called = False
+        self.method = method
+    
+    def __call__(self, *args, **kwargs):
+        try:
+            self.method(*args, **kwargs)
+        finally:
+            self.was_called = True
+
+    def __eq__(self):
+        return self.was_called
+
+class TestHelper(unittest.TestCase):
+    def assertCalled(self, bound_method, caller, *args, **kwargs):
+        bound_method = was_called(bound_method)
+        caller(*args, **kwargs)
+        self.assertTrue(bound_method)


### PR DESCRIPTION
When a merge fails we continue, but that calls **exit** which used to
delete the remote and branch. Instead we reset the branch, and now
**exit** calls git_client.Git.cleanup() instead.
