### PR TITLE
Don't silently eat valueerrors when parsing a configuration

### DIFF
--- a/roundabout/config.py
+++ b/roundabout/config.py
@@ -54,7 +54,7 @@ class Config(object):
         try:
             with open(config_file) as fp:
                 self.__dict__.update(json.load(fp))
-        except (TypeError, ValueError, IOError):
+        except (TypeError, IOError):
             pass
 
         self.validate()


### PR DESCRIPTION
Don't silently eat ValueError, if the json config is wrong, you need the debug info to see what went wrong. I spent a long time debugging a missing comma because I forgot json doesn't let you have a comma on the last value in a list :/
